### PR TITLE
ObjectMapper Added for Serializing ISO DateTime Strings

### DIFF
--- a/src/main/java/com/increff/employee/spring/ControllerConfig.java
+++ b/src/main/java/com/increff/employee/spring/ControllerConfig.java
@@ -79,5 +79,13 @@ public class ControllerConfig extends WebMvcConfigurerAdapter {
 		resolver.setTemplateMode(TemplateMode.HTML);
 		return resolver;
 	}
-
+	
+	@Bean
+	public ObjectMapper objectMapper() {
+        	JavaTimeModule javaTimeModule = new JavaTimeModule();
+        	javaTimeModule.addSerializer(ZonedDateTime.class,
+                	new ZonedDateTimeSerializer(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSXXX")));
+        	return Jackson2ObjectMapperBuilder.json().featuresToDisable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS) // ISODate
+                	.modules(javaTimeModule).build();
+    	}
 }


### PR DESCRIPTION
ObjectMapper Bean Configuration for conversion of ISO 8601 Timestamp Strings to ZonedDateTime Objects in Java